### PR TITLE
Fix various typos throughout the documentation

### DIFF
--- a/generated/bitcore-channel/docs/index.md
+++ b/generated/bitcore-channel/docs/index.md
@@ -19,7 +19,7 @@ bower install bitcore-channel --save
 ## Getting Started
 The library has two sides to it: the Consumer and the Provider of the services or goods that are being transacted.
 
-Let's start with an overview of how to use the Consumer side. Let's asume that we know the server's public key and that we have it in a string, encoded in hexa ascii values, in compressed format.
+Let's start with an overview of how to use the Consumer side. Let's assume that we know the server's public key and that we have it in a string, encoded in hexa ascii values, in compressed format.
 
 We also have a final address that we'll use as a "change" address (sending here any funds that we didn't transact with the Provider). We'll call this the "refund" address, as it will also be the address where the refund will get to in case the contract is cancelled.
 

--- a/generated/bitcore-lib/CONTRIBUTING.md
+++ b/generated/bitcore-lib/CONTRIBUTING.md
@@ -97,7 +97,7 @@ When possible, bitcore objects should have standard methods on an instance proto
 * `toBuffer` - A hex Buffer
 
 These should have a matching static method that can be used for instantiation:
-* `fromObject` - Should be able to instatiate with the output from `toObject/toJSON`
+* `fromObject` - Should be able to instantiate with the output from `toObject/toJSON`
 * `fromString` - Should be able to instantiate with output from `toString`
 * `fromBuffer` - Should likewise be able to instantiate from output from `toBuffer`
 

--- a/generated/bitcore-lib/docs/transaction.md
+++ b/generated/bitcore-lib/docs/transaction.md
@@ -131,7 +131,7 @@ There are a series of methods used for serialization:
 - `toJSON`: Will be called when using `JSON.stringify` to return JSON-encoded string using the output from `toObject`.
 - `toString` or `uncheckedSerialize`: Returns an hexadecimal serialization of the transaction, in the [serialization format for bitcoin](https://bitcoin.org/en/developer-reference#raw-transaction-format).
 - `serialize`: Does a series of checks before serializing the transaction
-- `inspect`: Returns a string with some information about the transaction (currently a string formated as `<Transaction 000...000>`, that only shows the serialized value of the transaction.
+- `inspect`: Returns a string with some information about the transaction (currently a string formatted as `<Transaction 000...000>`, that only shows the serialized value of the transaction.
 - `toBuffer`: Serializes the transaction for sending over the wire in the bitcoin network
 - `toBufferWriter`: Uses an already existing BufferWriter to copy over the serialized transaction
 
@@ -174,4 +174,4 @@ console.log(transaction.getLockTime());
 ```
 
 ## Upcoming changes
-We're debating an API for Merge Avoidance, CoinJoin, Smart contracts, CoinSwap, and Stealth Addresses. We're expecting to have all of them by some time in 2015. Payment channel creation is avaliable in the [bitcore-channel](https://github.com/bitpay/bitcore-channel) module.
+We're debating an API for Merge Avoidance, CoinJoin, Smart contracts, CoinSwap, and Stealth Addresses. We're expecting to have all of them by some time in 2015. Payment channel creation is available in the [bitcore-channel](https://github.com/bitpay/bitcore-channel) module.

--- a/generated/bitcore-lib/lib/block/blockheader.md
+++ b/generated/bitcore-lib/lib/block/blockheader.md
@@ -84,7 +84,7 @@ Returns the target difficulty for this block
 <a name="BlockHeader+inspect"></a>
 ### blockHeader.inspect() ⇒ <code>string</code>
 **Kind**: instance method of <code>[BlockHeader](#BlockHeader)</code>  
-**Returns**: <code>string</code> - - A string formated for the console  
+**Returns**: <code>string</code> - - A string formatted for the console  
 <a name="BlockHeader.fromObject"></a>
 ### BlockHeader.fromObject(obj) ⇒ <code>[BlockHeader](#BlockHeader)</code>
 **Kind**: static method of <code>[BlockHeader](#BlockHeader)</code>  

--- a/generated/bitcore-lib/lib/hdprivatekey.md
+++ b/generated/bitcore-lib/lib/hdprivatekey.md
@@ -52,7 +52,7 @@ Fields include:<ul>
 **Kind**: instance property of <code>[HDPrivateKey](#HDPrivateKey)</code>  
 <a name="HDPrivateKey+derive"></a>
 ### hdPrivateKey.derive(arg, hardened)
-Get a derivated child based on a string or number.
+Get a derived child based on a string or number.
 
 If the first argument is a string, it's parsed as the full path of
 derivation. Valid values for this argument include "m" (which returns the

--- a/generated/bitcore-lib/lib/script/script.md
+++ b/generated/bitcore-lib/lib/script/script.md
@@ -119,7 +119,7 @@ Adds a script element at the start of the script.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| obj | <code>\*</code> | a string, number, Opcode, Bufer, or object to add |
+| obj | <code>\*</code> | a string, number, Opcode, Buffer, or object to add |
 
 <a name="Script+equals"></a>
 ### script.equals()
@@ -135,7 +135,7 @@ Adds a script element to the end of the script.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| obj | <code>\*</code> | a string, number, Opcode, Bufer, or object to add |
+| obj | <code>\*</code> | a string, number, Opcode, Buffer, or object to add |
 
 <a name="Script+toScriptHashOut"></a>
 ### script.toScriptHashOut() ⇒ <code>[Script](#Script)</code>
@@ -157,7 +157,7 @@ Will return the associated address information object
 
 <a name="Script+findAndDelete"></a>
 ### script.findAndDelete()
-Analagous to bitcoind's FindAndDelete. Find and delete equivalent chunks,
+Analogous to bitcoind's FindAndDelete. Find and delete equivalent chunks,
 typically used with push data chunks.  Note that this will find and delete
 not just the same data, but the same data with the same push data op as
 produced by default. i.e., if a pushdata in a tx does not use the minimal
@@ -173,7 +173,7 @@ Comes from bitcoind's script interpreter CheckMinimalPush function
 **Returns**: <code>boolean</code> - if the chunk {i} is the smallest way to push that particular data.  
 <a name="Script+_decodeOP_N"></a>
 ### script._decodeOP_N(opcode) ⇒ <code>number</code>
-Comes from bitcoind's script DecodOP_N function
+Comes from bitcoind's script DecodeOP_N function
 
 **Kind**: instance method of <code>[Script](#Script)</code>  
 **Returns**: <code>number</code> - numeric value in range of 0 to 16  
@@ -262,7 +262,7 @@ Builds a scriptSig (a script for an input) that signs a public key output script
 
 | Param | Type | Description |
 | --- | --- | --- |
-| signature | <code>Signature</code> &#124; <code>Buffer</code> | a Signature object, or the signature in DER cannonical encoding |
+| signature | <code>Signature</code> &#124; <code>Buffer</code> | a Signature object, or the signature in DER canonical encoding |
 | [sigtype] | <code>number</code> | the type of the signature (defaults to SIGHASH_ALL) |
 
 <a name="Script.buildPublicKeyHashIn"></a>
@@ -275,7 +275,7 @@ output script.
 | Param | Type | Description |
 | --- | --- | --- |
 | publicKey | <code>Buffer</code> &#124; <code>string</code> &#124; <code>PublicKey</code> |  |
-| signature | <code>Signature</code> &#124; <code>Buffer</code> | a Signature object, or the signature in DER cannonical encoding |
+| signature | <code>Signature</code> &#124; <code>Buffer</code> | a Signature object, or the signature in DER canonical encoding |
 | [sigtype] | <code>number</code> | the type of the signature (defaults to SIGHASH_ALL) |
 
 <a name="Script.empty"></a>

--- a/generated/bitcore-lib/lib/transaction/transaction.md
+++ b/generated/bitcore-lib/lib/transaction/transaction.md
@@ -409,7 +409,7 @@ CheckTransaction in bitcoin core.
 **Kind**: instance method of <code>[Transaction](#Transaction)</code>  
 <a name="Transaction+isCoinbase"></a>
 ### transaction.isCoinbase()
-Analagous to bitcoind's IsCoinBase function in transaction.h
+Analogous to bitcoind's IsCoinBase function in transaction.h
 
 **Kind**: instance method of <code>[Transaction](#Transaction)</code>  
 <a name="Transaction.shallowCopy"></a>

--- a/generated/bitcore-lib/lib/transaction/unspentoutput.md
+++ b/generated/bitcore-lib/lib/transaction/unspentoutput.md
@@ -32,7 +32,7 @@ transaction id and output index.
 
 <a name="UnspentOutput+toObject"></a>
 ### unspentOutput.toObject ⇒ <code>object</code>
-Returns a plain object (no prototype or methods) with the associated infor for this output
+Returns a plain object (no prototype or methods) with the associated info for this output
 
 **Kind**: instance property of <code>[UnspentOutput](#UnspentOutput)</code>  
 <a name="UnspentOutput+inspect"></a>

--- a/generated/bitcore-lib/lib/uri.md
+++ b/generated/bitcore-lib/lib/uri.md
@@ -21,7 +21,7 @@ Bitcore URI
 
 Instantiate an URI from a bitcoin URI String or an Object. An URI instance
 can be created with a bitcoin uri string or an object. All instances of
-URI are valid, the static method isValid allows checking before instanciation.
+URI are valid, the static method isValid allows checking before instantiation.
 
 All standard parameters can be found as members of the class, the address
 is represented using an {Address} instance and the amount is represented in

--- a/generated/bitcore-node/lib/services/address/index.md
+++ b/generated/bitcore-node/lib/services/address/index.md
@@ -3,7 +3,7 @@
 The Address Service builds upon the Database Service and the Bitcoin Service to add additional
 functionality for getting information by base58check encoded addresses. This includes getting the
 balance for an address, the history for a collection of addresses, and unspent outputs for
-contstructing transactions. This is typically the core functionality for building a wallet.
+constructing transactions. This is typically the core functionality for building a wallet.
 
 **Kind**: global function  
 
@@ -26,7 +26,7 @@ contstructing transactions. This is typically the core functionality for buildin
   * [.balanceEventHandler(block, obj)](#AddressService+balanceEventHandler)
   * [.subscribe(name, emitter, addresses)](#AddressService+subscribe)
   * [.unsubscribe(name, emitter, addresses)](#AddressService+unsubscribe)
-  * [.unsubscribeAll(name, emiter)](#AddressService+unsubscribeAll)
+  * [.unsubscribeAll(name, emitter)](#AddressService+unsubscribeAll)
   * [.getBalance(address, queryMempool, callback)](#AddressService+getBalance)
   * [.getInputForOutput(txid, outputIndex, options, callback)](#AddressService+getInputForOutput)
   * [.getInputs(addressStr, options, callback)](#AddressService+getInputs)
@@ -89,7 +89,7 @@ mempoolOutputIndex, an object keyed by base58check encoded addresses with values
   satoshis - Total number of satoshis
   script - The script as a hex string
 
-mempoolInputIndex, an object keyed by base58check encoded addreses with values:
+mempoolInputIndex, an object keyed by base58check encoded addresses with values:
   txid - A hex string of the transaction hash
   inputIndex - A number of the corresponding input
 
@@ -188,7 +188,7 @@ events for this service.
 | addresses | <code>Array</code> | An array of addresses to subscribe |
 
 <a name="AddressService+unsubscribeAll"></a>
-### addressService.unsubscribeAll(name, emiter)
+### addressService.unsubscribeAll(name, emitter)
 A helper function for the `unsubscribe` method to unsubscribe from all addresses.
 
 **Kind**: instance method of <code>[AddressService](#AddressService)</code>  

--- a/generated/bitcore-node/lib/services/bitcoind.md
+++ b/generated/bitcore-node/lib/services/bitcoind.md
@@ -54,7 +54,7 @@ Helper to determine the progress of the database.
 **Returns**: <code>Number</code> - An estimated percentage of the syncronization status  
 <a name="Bitcoin+getBlock"></a>
 ### bitcoin.getBlock(block)
-Will retreive a block as a Node.js Buffer from disk.
+Will retrieve a block as a Node.js Buffer from disk.
 
 **Kind**: instance method of <code>[Bitcoin](#Bitcoin)</code>  
 
@@ -136,7 +136,7 @@ Will get a transaction as a Node.js Buffer from disk and the mempool.
 
 <a name="Bitcoin+getTransactionWithBlockInfo"></a>
 ### bitcoin.getTransactionWithBlockInfo(txid, queryMempool, callback)
-Will get a transation with additional information about the block, in the format:
+Will get a transaction with additional information about the block, in the format:
 {
   blockHash: '2725743288feae6bdaa976590af7cb12d7b535b5a242787de6d2789c73682ed1',
   height: 48,

--- a/generated/bitcore-node/lib/services/web.md
+++ b/generated/bitcore-node/lib/services/web.md
@@ -1,6 +1,6 @@
 <a name="WebService"></a>
 ## WebService(options)
-This service respresents a hub for combining several services over a single HTTP port. Services
+This service represents a hub for combining several services over a single HTTP port. Services
 can extend routes by implementing the methods `getRoutePrefix` and `setupRoutes`. Additionally
 events that are exposed via the `getPublishEvents` and API methods exposed via `getAPIMethods`
 will be available over a socket.io connection.
@@ -56,7 +56,7 @@ all of the exposed HTTP routes.
 **Kind**: instance method of <code>[WebService](#WebService)</code>  
 <a name="WebService+createMethodsMap"></a>
 ### webService.createMethodsMap()
-This function will contruct an API methods map of all of the
+This function will construct an API methods map of all of the
 available methods that can be called from enable services.
 
 **Kind**: instance method of <code>[WebService](#WebService)</code>  

--- a/generated/bitcore-p2p/docs/index.md
+++ b/generated/bitcore-p2p/docs/index.md
@@ -1,8 +1,8 @@
 # Peer-to-Peer
-The `bitcore-p2p` module provides peer-to-peer networking capabilites for [Bitcore](https://github.com/bitpay/bitcore), and includes [Peer](peer.md) and [Pool](pool.md) classes. A [Message](messages.md) class is also exposed, in addition to [several types of messages](messages.md). Pool will maintain connection to several peers, Peers represents a node in the bitcoin network, and Message represents data sent to and from a Peer. For detailed technical information about the bitcoin protocol, please visit the [Protocol Specification](https://en.bitcoin.it/wiki/Protocol_specification) on the Bitcoin Wiki.
+The `bitcore-p2p` module provides peer-to-peer networking capabilities for [Bitcore](https://github.com/bitpay/bitcore), and includes [Peer](peer.md) and [Pool](pool.md) classes. A [Message](messages.md) class is also exposed, in addition to [several types of messages](messages.md). Pool will maintain connection to several peers, Peers represents a node in the bitcoin network, and Message represents data sent to and from a Peer. For detailed technical information about the bitcoin protocol, please visit the [Protocol Specification](https://en.bitcoin.it/wiki/Protocol_specification) on the Bitcoin Wiki.
 
 ## Installation
-Peer-to-peer is implemented as a seperate module.
+Peer-to-peer is implemented as a separate module.
 
 For node projects:
 

--- a/generated/bitcore-p2p/lib/pool.md
+++ b/generated/bitcore-p2p/lib/pool.md
@@ -48,7 +48,7 @@ pool.connect();
 ```
 <a name="Pool+connect"></a>
 ### pool.connect()
-Will initiatiate connection to peers, if available peers have been added to
+Will initiate connection to peers, if available peers have been added to
 the pool, it will connect to those, otherwise will use DNS seeds to find
 peers to connect. When a peer disconnects it will add another.
 
@@ -64,7 +64,7 @@ Will disconnect all peers that are connected.
 **Returns**: <code>Number</code> - The number of peers currently connected.  
 <a name="Pool+_fillConnections"></a>
 ### pool._fillConnections()
-Will fill the conneted peers to the maximum amount.
+Will fill the connected peers to the maximum amount.
 
 **Kind**: instance method of <code>[Pool](#Pool)</code>  
 <a name="Pool+_removeConnectedPeer"></a>
@@ -101,7 +101,7 @@ intializes the associated event handlers.
 
 <a name="Pool+_addPeerEventHandlers"></a>
 ### pool._addPeerEventHandlers()
-Will add disconnect and ready events for a peer and intialize
+Will add disconnect and ready events for a peer and initialize
 handlers for relay peer message events.
 
 **Kind**: instance method of <code>[Pool](#Pool)</code>  

--- a/src/api/release.jade
+++ b/src/api/release.jade
@@ -3,7 +3,7 @@ extends ../_layouts/api
 append vars
   -var section = 'node';
   -var title = 'Release Process';
-  -var description = 'Explaination of Bitcore release and signature verification process.';
+  -var description = 'Explanation of Bitcore release and signature verification process.';
 
 block docs
   .section.p-t-md

--- a/src/guides/i-made-this/i-made-this.md
+++ b/src/guides/i-made-this/i-made-this.md
@@ -212,7 +212,7 @@ StampingService.prototype.blockHandler = function(block, add, callback) {
 
 The lookupHash method shown below will be called by the client-side code whenever a user uploads a file to
 check whether that file has already been timestamped. This method will query the data that has
-been stored by the blockHanlder method above.
+been stored by the blockHandler method above.
 
 ```javascript
 StampingService.prototype.lookupHash = function(req, res, next) {

--- a/src/guides/wallet-service/wallet-service.md
+++ b/src/guides/wallet-service/wallet-service.md
@@ -1,6 +1,6 @@
 # Running a Wallet Service
 
-The purpose of this tutorial is to show how to setup the Wallet Service. The Wallet Service is the backend for wallets such as BitPay's [Copay Mutisignature Wallet](https://copay.io). The wallet service is very much like the backend for traditional SPV (Simplified Payment Verification) wallets except that the wallet service is much more feature-full.
+The purpose of this tutorial is to show how to setup the Wallet Service. The Wallet Service is the backend for wallets such as BitPay's [Copay Multisignature Wallet](https://copay.io). The wallet service is very much like the backend for traditional SPV (Simplified Payment Verification) wallets except that the wallet service is much more feature-full.
 
 ## Installing Dependencies
 


### PR DESCRIPTION
This also includes some changes to examples in services.md via suggestions from braydon from a while back.
