### PR TITLE
Update Bitcore MailChimp Form

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -35,7 +35,7 @@ block body
           iframe.pull-right.hidden-xs-down(src="https://ghbtns.com/github-btn.html?user=bitpay&repo=bitcore&type=fork&count=true&size=large&count=true" frameborder="0" scrolling="0" width="132px" height="30px")
           iframe.pull-right.hidden-xs-down(src="https://ghbtns.com/github-btn.html?user=bitpay&repo=bitcore&type=star&count=true&size=large&count=true" frameborder="0" scrolling="0" width="150px" height="30px")
         .col-lg-4.col-md-6.col-xs-12.bc-subscription.input-group
-          form.validate(action='//bitcore.us7.list-manage.com/subscribe/post?u=29605d300e62d91f5e2520c67&id=c3d06574f5', method='post', name='mc-embedded-subscribe-form', target='_blank', novalidate='')
+          form.validate(action='http://eepurl.com/NPjwH', method='post', name='mc-embedded-subscribe-form', target='_blank', novalidate='')
             div.bc-subscription.input-group
               input.required.email.form-control(type='email', value='', name='EMAIL')
               div(style='position: absolute; left: -5000px;')


### PR DESCRIPTION
For GDPR

This isn't the prettiest solution, but since we're moving to GDPR forms hosted on MailChimp (for now at least) this is a minimally-invasive surgical change to get us compliant.